### PR TITLE
Supporting `rocrand_generate_poisson` in HIP Graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Documentation for rocRAND is available at
 ### Additions
 
 * Added host generator for MT19937
+* Support for `rocrand_generate_poisson` in hipGraphs
 
 ### Changes
 

--- a/benchmark/tuning/benchmark_tuning.hpp
+++ b/benchmark/tuning/benchmark_tuning.hpp
@@ -88,7 +88,10 @@ void run_benchmark(benchmark::State& state, const benchmark_config& config)
     generator.set_stream(stream);
 
     const auto generate_func = [&]
-    { return generator.generate(data, size, default_distribution<Distribution>{}(config)); };
+    {
+        default_distribution<Distribution> default_distribution_provider;
+        return generator.generate(data, size, default_distribution_provider(config));
+    };
 
     // Warm-up
     ROCRAND_CHECK(generate_func());
@@ -147,9 +150,7 @@ public:
             if constexpr(std::is_same_v<T, unsigned int>)
             {
                 // The poisson distribution is only supported for unsigned int.
-                using poisson_distribution_t = rocrand_impl::host::poisson_distribution<
-                    rocrand_impl::host::DISCRETE_METHOD_ALIAS>;
-                add_benchmarks_impl<T, poisson_distribution_t>();
+                add_benchmarks_impl<T, select_poisson_distribution_t<GeneratorTemplate>>();
             }
         }
         else if constexpr(std::is_floating_point_v<T> || std::is_same_v<T, half>)

--- a/library/src/rng/distribution/discrete.hpp
+++ b/library/src/rng/distribution/discrete.hpp
@@ -25,9 +25,11 @@
 
 #include <rocrand/rocrand.h>
 #include <rocrand/rocrand_discrete.h>
+#include <rocrand/rocrand_discrete_types.h>
 
 #include <algorithm>
 #include <climits>
+#include <iterator>
 #include <vector>
 
 // Alias method
@@ -48,174 +50,175 @@ enum discrete_method
     DISCRETE_METHOD_UNIVERSAL = DISCRETE_METHOD_ALIAS | DISCRETE_METHOD_CDF
 };
 
-template<discrete_method Method = DISCRETE_METHOD_ALIAS, bool IsHostSide = false>
-class discrete_distribution_base : public rocrand_discrete_distribution_st
+/// \brief Encapsulates a `rocrand_discrete_distribution_st` and makes it possible
+/// to sample the discrete distribution in the host generators.
+template<discrete_method Method>
+class discrete_distribution_base
 {
 public:
-
-    static constexpr unsigned int input_width = 1;
-    static constexpr unsigned int output_width = 1;
+    static constexpr inline unsigned int input_width  = 1;
+    static constexpr inline unsigned int output_width = 1;
 
     // rocrand_discrete_distribution_st is a struct
-    discrete_distribution_base() // cppcheck-suppress uninitDerivedMemberVar
-    {
-        size = 0;
-        offset      = 0;
-        probability = NULL;
-        alias = NULL;
-        cdf = NULL;
-    }
-
-    discrete_distribution_base(const double* probabilities, unsigned int size, unsigned int offset)
-        : discrete_distribution_base()
-    {
-        std::vector<double> p(probabilities, probabilities + size);
-
-        init(p, size, offset);
-    }
-
-    __host__ __device__ ~discrete_distribution_base() {}
-
-    void deallocate()
-    {
-        // Explicit deallocation is used because the object is copied
-        // multiple times inside hipLaunchKernelGGL, and destructor is called
-        // for all copies (we can't use c++ smart pointers for device pointers)
-        if (IsHostSide)
-        {
-            if (probability != NULL)
-            {
-                delete[] probability;
-            }
-            if (alias != NULL)
-            {
-                delete[] alias;
-            }
-            if (cdf != NULL)
-            {
-                delete[] cdf;
-            }
-        }
-        else
-        {
-            if (probability != NULL)
-            {
-                ROCRAND_HIP_FATAL_ASSERT(hipFree(probability));
-            }
-            if (alias != NULL)
-            {
-                ROCRAND_HIP_FATAL_ASSERT(hipFree(alias));
-            }
-            if (cdf != NULL)
-            {
-                ROCRAND_HIP_FATAL_ASSERT(hipFree(cdf));
-            }
-        }
-        probability = NULL;
-        alias = NULL;
-        cdf = NULL;
-    }
+    explicit discrete_distribution_base(const rocrand_discrete_distribution_st& distribution)
+        : m_distribution(distribution)
+    {}
 
     template<class T>
     __forceinline__ __host__ __device__ unsigned int operator()(T x) const
     {
-        if((Method & DISCRETE_METHOD_ALIAS) != 0)
+        if constexpr((Method & DISCRETE_METHOD_ALIAS) != 0)
         {
-            return rocrand_device::detail::discrete_alias(x, *this);
+            return rocrand_device::detail::discrete_alias(x, m_distribution);
         }
         else
         {
-            return rocrand_device::detail::discrete_cdf(x, *this);
+            return rocrand_device::detail::discrete_cdf(x, m_distribution);
         }
     }
 
     template<class T>
-    __host__ __device__ void operator()(const T (&input)[1], unsigned int output[1]) const
+    __forceinline__ __host__ __device__ void operator()(const T (&input)[1],
+                                                        unsigned int output[1]) const
     {
         output[0] = (*this)(input[0]);
     }
 
-protected:
+private:
+    rocrand_discrete_distribution_st m_distribution;
+};
 
-    void init(std::vector<double> p,
-              const unsigned int size,
-              const unsigned int offset)
+/// \brief A collection of static methods for constructing and destroying
+/// instances of `rocrand_discrete_distribution_st`.
+/// \tparam Method Controls which members of the produced `rocrand_discrete_distribution_st`
+/// are populated.
+/// \tparam IsHostSide Controls whether the allocated and filled memory blocks reside
+/// on the host or on the device.
+template<discrete_method Method, bool IsHostSide = false>
+class discrete_distribution_factory
+{
+public:
+    /// \brief Allocates and populates an instance of `rocrand_discrete_distribution_st`.
+    /// \note `allocate` and `normalize` are called by this function, therefore those
+    /// doesn't need to be called separately.
+    /// \note The produced `rocrand_discrete_distribution_st` MUST be deallocated by the matching
+    /// `deallocate` function when it's no longer used.
+    /// \param p The probability array of the discrete distribution.
+    /// \param size The size of the input probability array. This must not exceed the size of `p`.
+    /// \param offset The offset of the input probability array.
+    /// \param distribution [out] The allocated and populated discrete distribution instance.
+    /// \return `ROCRAND_STATUS_SUCCESS` if the operation is successful, otherwise an error code from the
+    /// first failing procedure.
+    static rocrand_status create(std::vector<double>               p,
+                                 const unsigned int                size,
+                                 const unsigned int                offset,
+                                 rocrand_discrete_distribution_st& distribution)
     {
-        this->size = size;
-        this->offset = offset;
-
-        deallocate();
-        allocate();
-        normalize(p);
-        if((Method & DISCRETE_METHOD_ALIAS) != 0)
+        rocrand_status status = allocate(size, offset, distribution);
+        if(status != ROCRAND_STATUS_SUCCESS)
         {
-            create_alias_table(p);
+            return status;
         }
-        if((Method & DISCRETE_METHOD_CDF) != 0)
+        normalize(p, size);
+        if constexpr((Method & DISCRETE_METHOD_ALIAS) != 0)
         {
-            create_cdf(p);
+            std::vector<double>       h_probability(size);
+            std::vector<unsigned int> h_alias(size);
+            create_alias_table(p, size, h_probability.begin(), h_alias.begin());
+            status = copy_alias_table(distribution, h_probability, h_alias);
+            if(status != ROCRAND_STATUS_SUCCESS)
+            {
+                return status;
+            }
         }
+        if constexpr((Method & DISCRETE_METHOD_CDF) != 0)
+        {
+            std::vector<double> h_cdf(size);
+            create_cdf(p, size, h_cdf.begin());
+            status = copy_cdf(distribution, h_cdf);
+            if(status != ROCRAND_STATUS_SUCCESS)
+            {
+                return status;
+            }
+        }
+        return ROCRAND_STATUS_SUCCESS;
     }
 
-    void allocate()
+    /// \brief Frees the allocated memory associated with the passed distribution that was
+    /// previously created by `create` or `allocate`.
+    /// \param [in,out] distribution The distribution to deallocate.
+    /// The fields of the distribution are set to default values.
+    /// \return `ROCRAND_STATUS_SUCCESS` if the operation is successful, otherwise an error code from the
+    /// first failing procedure.
+    static rocrand_status deallocate(rocrand_discrete_distribution_st& distribution)
     {
-        if (IsHostSide)
+        if constexpr(IsHostSide)
         {
-            if((Method & DISCRETE_METHOD_ALIAS) != 0)
-            {
-                probability = new double[size];
-                alias = new unsigned int[size];
-            }
-            if((Method & DISCRETE_METHOD_CDF) != 0)
-            {
-                cdf = new double[size];
-            }
+            delete[] distribution.probability;
+            delete[] distribution.alias;
+            delete[] distribution.cdf;
         }
         else
         {
             hipError_t error;
-            if((Method & DISCRETE_METHOD_ALIAS) != 0)
+            error = hipFree(distribution.probability);
+            if(error != hipSuccess)
             {
-                error = hipMalloc(&probability, sizeof(double) * size);
-                if (error != hipSuccess)
-                {
-                    throw ROCRAND_STATUS_ALLOCATION_FAILED;
-                }
-                error = hipMalloc(&alias, sizeof(unsigned int) * size);
-                if (error != hipSuccess)
-                {
-                    throw ROCRAND_STATUS_ALLOCATION_FAILED;
-                }
+                return ROCRAND_STATUS_INTERNAL_ERROR;
             }
-            if((Method & DISCRETE_METHOD_CDF) != 0)
+            error = hipFree(distribution.alias);
+            if(error != hipSuccess)
             {
-                error = hipMalloc(&cdf, sizeof(double) * size);
-                if (error != hipSuccess)
-                {
-                    throw ROCRAND_STATUS_ALLOCATION_FAILED;
-                }
+                return ROCRAND_STATUS_INTERNAL_ERROR;
+            }
+            error = hipFree(distribution.cdf);
+            if(error != hipSuccess)
+            {
+                return ROCRAND_STATUS_INTERNAL_ERROR;
             }
         }
+
+        distribution = {};
+        return ROCRAND_STATUS_SUCCESS;
     }
 
-    void normalize(std::vector<double>& p) const
+    /// \brief Normalizes the values in probability vector `p`.
+    /// \param p [in,out] p The probability vector to normalize.
+    /// \param size The size of the probability vector.
+    /// It MUST NOT be larger than the size of `p`.
+    static void normalize(std::vector<double>& p, const unsigned int size)
     {
         double sum = 0.0;
-        for (unsigned int i = 0; i < size; i++)
+        for(unsigned int i = 0; i < size; i++)
         {
             sum += p[i];
         }
-        // Normalize probabilities
-        for (unsigned int i = 0; i < size; i++)
+        for(unsigned int i = 0; i < size; i++)
         {
             p[i] /= sum;
         }
     }
 
-    void create_alias_table(std::vector<double> p)
+    /// \brief Computes the alias table from the probability vector for a discrete distribution.
+    /// \tparam ProbabilityIt The type of the output iterator to which the calculated probabilities are written.
+    /// Must be a RandomAccessIterator.
+    /// \tparam AliasIt The type of the output iterator to which the calculated aliases are written.
+    /// Must be a RandomAccessIterator.
+    /// \param p The normalized probability vector.
+    /// \param size The size of the probability vector.
+    /// It MUST NOT be larger than the size of `p`.
+    /// \param h_probability Probabilities output iterator.
+    /// \param h_alias Aliases output iterator.
+    template<class ProbabilityIt, class AliasIt>
+    static void create_alias_table(std::vector<double> p,
+                                   const unsigned int  size,
+                                   ProbabilityIt       h_probability,
+                                   AliasIt             h_alias)
     {
-        std::vector<double> h_probability(size);
-        std::vector<unsigned int> h_alias(size);
+        static_assert(
+            std::is_same_v<double, typename std::iterator_traits<ProbabilityIt>::value_type>);
+        static_assert(
+            std::is_same_v<unsigned int, typename std::iterator_traits<AliasIt>::value_type>);
 
         const double average = 1.0 / size;
 
@@ -259,52 +262,135 @@ protected:
         {
             h_probability[i] = 1.0;
         }
-
-        if (IsHostSide)
-        {
-            std::copy(h_probability.begin(), h_probability.end(), probability);
-            std::copy(h_alias.begin(), h_alias.end(), alias);
-        }
-        else
-        {
-            hipError_t error;
-            error = hipMemcpy(probability, h_probability.data(), sizeof(double) * size, hipMemcpyDefault);
-            if (error != hipSuccess)
-            {
-                throw ROCRAND_STATUS_INTERNAL_ERROR;
-            }
-            error = hipMemcpy(alias, h_alias.data(), sizeof(unsigned int) * size, hipMemcpyDefault);
-            if (error != hipSuccess)
-            {
-                throw ROCRAND_STATUS_INTERNAL_ERROR;
-            }
-        }
     }
 
-    void create_cdf(std::vector<double> p)
+    /// \brief Computes the CDF (cumulative distribution function) table from the
+    /// probability vector for a discrete distribution.
+    /// \tparam CdfIt The type of the output iterator to which the calculated CDF values are written.
+    /// Must be a RandomAccessIterator.
+    /// \param p The normalized probability vector.
+    /// \param size The size of the probability vector.
+    /// It MUST NOT be larger than the size of `p`.
+    /// \param h_cdf CDF output iterator.
+    template<class CdfIt>
+    static void create_cdf(const std::vector<double>& p, const unsigned int size, CdfIt h_cdf)
     {
-        std::vector<double> h_cdf(size);
+        static_assert(std::is_same_v<double, typename std::iterator_traits<CdfIt>::value_type>);
 
         double sum = 0.0;
-        for (unsigned int i = 0; i < size; i++)
+        for(unsigned int i = 0; i < size; i++)
         {
             sum += p[i];
             h_cdf[i] = sum;
         }
+    }
 
-        if (IsHostSide)
+    /// \brief Allocates the required amount of memory for a `rocrand_discrete_distribution_st`.
+    /// \param size The size of the input probability array.
+    /// \param offset The offset of the input probability array.
+    /// \param [out] distribution The distribution to allocate.
+    /// \return `ROCRAND_STATUS_SUCCESS` if the operation is successful, otherwise an error code from the
+    /// first failing procedure.
+    static rocrand_status allocate(const unsigned int                size,
+                                   const unsigned int                offset,
+                                   rocrand_discrete_distribution_st& distribution)
+    {
+        distribution        = {};
+        distribution.size   = size;
+        distribution.offset = offset;
+        if constexpr(IsHostSide)
         {
-            std::copy(h_cdf.begin(), h_cdf.end(), cdf);
+            if constexpr((Method & DISCRETE_METHOD_ALIAS) != 0)
+            {
+                distribution.probability = new double[distribution.size];
+                distribution.alias       = new unsigned int[distribution.size];
+            }
+            if constexpr((Method & DISCRETE_METHOD_CDF) != 0)
+            {
+                distribution.cdf = new double[distribution.size];
+            }
         }
         else
         {
             hipError_t error;
-            error = hipMemcpy(cdf, h_cdf.data(), sizeof(double) * size, hipMemcpyDefault);
-            if (error != hipSuccess)
+            if constexpr((Method & DISCRETE_METHOD_ALIAS) != 0)
             {
-                throw ROCRAND_STATUS_INTERNAL_ERROR;
+                error = hipMalloc(&distribution.probability, sizeof(double) * distribution.size);
+                if(error != hipSuccess)
+                {
+                    return ROCRAND_STATUS_ALLOCATION_FAILED;
+                }
+                error = hipMalloc(&distribution.alias, sizeof(unsigned int) * distribution.size);
+                if(error != hipSuccess)
+                {
+                    return ROCRAND_STATUS_ALLOCATION_FAILED;
+                }
+            }
+            if constexpr((Method & DISCRETE_METHOD_CDF) != 0)
+            {
+                error = hipMalloc(&distribution.cdf, sizeof(double) * distribution.size);
+                if(error != hipSuccess)
+                {
+                    return ROCRAND_STATUS_ALLOCATION_FAILED;
+                }
             }
         }
+        return ROCRAND_STATUS_SUCCESS;
+    }
+
+private:
+    static rocrand_status copy_alias_table(const rocrand_discrete_distribution_st& distribution,
+                                           const std::vector<double>&              h_probability,
+                                           const std::vector<unsigned int>&        h_alias)
+    {
+        if constexpr(IsHostSide)
+        {
+            std::copy(h_probability.begin(), h_probability.end(), distribution.probability);
+            std::copy(h_alias.begin(), h_alias.end(), distribution.alias);
+        }
+        else
+        {
+            hipError_t error;
+            error = hipMemcpy(distribution.probability,
+                              h_probability.data(),
+                              sizeof(double) * distribution.size,
+                              hipMemcpyHostToDevice);
+            if(error != hipSuccess)
+            {
+                return ROCRAND_STATUS_INTERNAL_ERROR;
+            }
+            error = hipMemcpy(distribution.alias,
+                              h_alias.data(),
+                              sizeof(unsigned int) * distribution.size,
+                              hipMemcpyHostToDevice);
+            if(error != hipSuccess)
+            {
+                return ROCRAND_STATUS_INTERNAL_ERROR;
+            }
+        }
+        return ROCRAND_STATUS_SUCCESS;
+    }
+
+    static rocrand_status copy_cdf(const rocrand_discrete_distribution_st& distribution,
+                                   const std::vector<double>&              h_cdf)
+    {
+        if constexpr(IsHostSide)
+        {
+            std::copy(h_cdf.begin(), h_cdf.end(), distribution.cdf);
+        }
+        else
+        {
+            hipError_t error;
+            error = hipMemcpy(distribution.cdf,
+                              h_cdf.data(),
+                              sizeof(double) * distribution.size,
+                              hipMemcpyHostToDevice);
+            if (error != hipSuccess)
+            {
+                return ROCRAND_STATUS_INTERNAL_ERROR;
+            }
+        }
+        return ROCRAND_STATUS_SUCCESS;
     }
 };
 

--- a/library/src/rng/distribution/poisson.hpp
+++ b/library/src/rng/distribution/poisson.hpp
@@ -21,144 +21,358 @@
 #ifndef ROCRAND_RNG_DISTRIBUTION_POISSON_H_
 #define ROCRAND_RNG_DISTRIBUTION_POISSON_H_
 
+#include "../system.hpp"
 #include "discrete.hpp"
 
 #include <rocrand/rocrand.h>
+#include <rocrand/rocrand_discrete_types.h>
+#include <rocrand/rocrand_poisson.h>
 #include <rocrand/rocrand_uniform.h>
 
 #include <algorithm>
+#include <cassert>
 #include <climits>
+#include <memory>
+#include <mutex>
+#include <utility>
+#include <variant>
 #include <vector>
 
 namespace rocrand_impl::host
 {
 
-template<discrete_method Method = DISCRETE_METHOD_ALIAS, bool IsHostSide = false>
-class poisson_distribution : public discrete_distribution_base<Method, IsHostSide>
+template<discrete_method Method = DISCRETE_METHOD_ALIAS>
+class poisson_distribution : private discrete_distribution_base<Method>
 {
 public:
-    typedef discrete_distribution_base<Method, IsHostSide> base;
+    static constexpr inline unsigned int input_width  = 1;
+    static constexpr inline unsigned int output_width = 1;
 
-    poisson_distribution() : base() {}
+    using base_t = discrete_distribution_base<Method>;
 
-    explicit poisson_distribution(double lambda) : poisson_distribution()
+    poisson_distribution(const rocrand_discrete_distribution_st& distribution, const double lambda)
+        : base_t(distribution), m_lambda(lambda)
+    {}
+
+    template<class T>
+    __forceinline__ __host__ __device__ unsigned int operator()(T x) const
     {
-        set_lambda(lambda);
+        if(m_lambda > rocrand_device::detail::lambda_threshold_huge)
+        {
+            const double normal_d = rocrand_device::detail::normal_distribution_double(x);
+            return static_cast<unsigned int>(round(sqrt(m_lambda) * normal_d + m_lambda));
+        }
+        else
+        {
+            return base_t::operator()(x);
+        }
     }
 
-    void set_lambda(double lambda)
+    template<class T>
+    __forceinline__ __host__ __device__ void operator()(const T (&input)[1],
+                                                        unsigned int (&output)[1]) const
     {
-        const size_t capacity =
-            2 * static_cast<size_t>(16.0 * (2.0 + std::sqrt(lambda)));
-        std::vector<double> p(capacity);
-
-        calculate_probabilities(p, capacity, lambda);
-
-        this->init(p, this->size, this->offset);
+        output[0] = (*this)(input[0]);
     }
 
-protected:
-
-    void calculate_probabilities(std::vector<double>& p, const size_t capacity,
-                                 const double lambda)
-    {
-        const double p_epsilon = 1e-12;
-        const double log_lambda = std::log(lambda);
-
-        const int left = static_cast<int>(std::floor(lambda)) - capacity / 2;
-
-        // Calculate probabilities starting from mean in both directions,
-        // because only a small part of [0, lambda] has non-negligible values
-        // (> p_epsilon).
-
-        int lo = 0;
-        for (int i = capacity / 2; i >= 0; i--)
-        {
-            const double x = left + i;
-            const double pp = std::exp(x * log_lambda - std::lgamma(x + 1.0) - lambda);
-            if (pp < p_epsilon)
-            {
-                lo = i + 1;
-                break;
-            }
-            p[i] = pp;
-        }
-
-        int hi = capacity - 1;
-        for (int i = capacity / 2 + 1; i < static_cast<int>(capacity); i++)
-        {
-            const double x = left + i;
-            const double pp = std::exp(x * log_lambda - std::lgamma(x + 1.0) - lambda);
-            if (pp < p_epsilon)
-            {
-                hi = i - 1;
-                break;
-            }
-            p[i] = pp;
-        }
-
-        for (int i = lo; i <= hi; i++)
-        {
-            p[i - lo] = p[i];
-        }
-
-        this->size = hi - lo + 1;
-        this->offset = left + lo;
-    }
+private:
+    double m_lambda;
 };
+
+[[nodiscard]] inline std::vector<double>
+    calculate_poisson_probabilities(const double lambda, unsigned int& size, unsigned int& offset)
+{
+    const size_t        capacity = 2 * static_cast<size_t>(16.0 * (2.0 + std::sqrt(lambda)));
+    std::vector<double> p(capacity);
+
+    const double p_epsilon  = 1e-12;
+    const double log_lambda = std::log(lambda);
+
+    const int left = static_cast<int>(std::floor(lambda)) - capacity / 2;
+
+    // Calculate probabilities starting from mean in both directions,
+    // because only a small part of [0, lambda] has non-negligible values
+    // (> p_epsilon).
+
+    int lo = 0;
+    for(int i = capacity / 2; i >= 0; i--)
+    {
+        const double x  = left + i;
+        const double pp = std::exp(x * log_lambda - std::lgamma(x + 1.0) - lambda);
+        if(pp < p_epsilon)
+        {
+            lo = i + 1;
+            break;
+        }
+        p[i] = pp;
+    }
+
+    int hi = capacity - 1;
+    for(int i = capacity / 2 + 1; i < static_cast<int>(capacity); i++)
+    {
+        const double x  = left + i;
+        const double pp = std::exp(x * log_lambda - std::lgamma(x + 1.0) - lambda);
+        if(pp < p_epsilon)
+        {
+            hi = i - 1;
+            break;
+        }
+        p[i] = pp;
+    }
+
+    for(int i = lo; i <= hi; i++)
+    {
+        p[i - lo] = p[i];
+    }
+
+    size   = hi - lo + 1;
+    offset = left + lo;
+
+    return p;
+}
+
+inline void calculate_poisson_size(const double lambda, unsigned int& size, unsigned int& offset)
+{
+    (void)calculate_poisson_probabilities(lambda, size, offset);
+}
 
 // Handles caching of precomputed tables for the distribution and recomputes
 // them only when lambda is changed (as these computations, device memory
 // allocations and copying take time).
-template<discrete_method Method = DISCRETE_METHOD_ALIAS, bool IsHostSide = false>
+template<discrete_method Method = DISCRETE_METHOD_ALIAS, class System = system::device_system>
 class poisson_distribution_manager
 {
 public:
-    poisson_distribution<Method, IsHostSide> dis;
+    using factory_t      = discrete_distribution_factory<Method, !System::is_device()>;
+    using distribution_t = poisson_distribution<Method>;
 
     poisson_distribution_manager() = default;
 
     poisson_distribution_manager(const poisson_distribution_manager&) = delete;
 
     poisson_distribution_manager(poisson_distribution_manager&& other)
-        : dis(other.dis), lambda(other.lambda)
-    {
-        // For now, we didn't make poisson_distribution move-only
-        // We copied the pointers of dis. Prevent deallocation by the destructor of other
-        other.dis = {};
-    }
+        : m_initialized(std::exchange(other.m_initialized, false))
+        , m_is_host_func_blocking(other.m_is_host_func_blocking)
+        , m_stream(other.m_stream)
+        , m_probability(std::exchange(other.m_probability, nullptr))
+        , m_alias(std::exchange(other.m_alias, nullptr))
+        , m_cdf(std::exchange(other.m_cdf, nullptr))
+        , m_lambda(other.m_lambda)
+        , m_distribution(std::exchange(other.m_distribution, {}))
+    {}
 
     poisson_distribution_manager& operator=(const poisson_distribution_manager&) = delete;
 
     poisson_distribution_manager& operator=(poisson_distribution_manager&& other)
     {
-        dis    = other.dis;
-        lambda = other.lambda;
-
-        // For now, we didn't make poisson_distribution move-only
-        // We copied the pointers of dis. Prevent deallocation by the destructor of other
-        other.dis = {};
+        m_initialized           = other.m_initialized;
+        m_is_host_func_blocking = other.m_is_host_func_blocking;
+        m_stream                = other.m_stream;
+        m_lambda                = other.lambda;
+        std::swap(m_probability, other.m_probability);
+        std::swap(m_alias, other.m_alias);
+        std::swap(m_cdf, other.m_cdf);
+        std::swap(m_distribution, other.m_distribution);
 
         return *this;
     }
 
     ~poisson_distribution_manager()
     {
-        dis.deallocate();
-    }
-
-    void set_lambda(double new_lambda)
-    {
-        const bool changed = lambda != new_lambda;
-        if (changed)
+        factory_t::deallocate(m_distribution);
+        if constexpr((Method & DISCRETE_METHOD_ALIAS) != 0)
         {
-            lambda = new_lambda;
-            dis.set_lambda(lambda);
+            ROCRAND_HIP_FATAL_ASSERT(hipHostFree(m_probability));
+            ROCRAND_HIP_FATAL_ASSERT(hipHostFree(m_alias));
+        }
+        if constexpr((Method & DISCRETE_METHOD_CDF) != 0)
+        {
+            ROCRAND_HIP_FATAL_ASSERT(hipHostFree(m_cdf));
         }
     }
 
+    rocrand_status init()
+    {
+        if(m_initialized)
+        {
+            return ROCRAND_STATUS_SUCCESS;
+        }
+
+        unsigned int size;
+        unsigned int offset;
+        calculate_poisson_size(rocrand_device::detail::lambda_threshold_huge, size, offset);
+        if constexpr((Method & DISCRETE_METHOD_ALIAS) != 0)
+        {
+            hipError_t error = hipHostMalloc(&m_probability, size * sizeof(*m_probability));
+            if(error != hipSuccess)
+            {
+                return ROCRAND_STATUS_ALLOCATION_FAILED;
+            }
+            error = hipHostMalloc(&m_alias, size * sizeof(*m_alias));
+            if(error != hipSuccess)
+            {
+                return ROCRAND_STATUS_ALLOCATION_FAILED;
+            }
+        }
+        if constexpr((Method & DISCRETE_METHOD_CDF) != 0)
+        {
+            const hipError_t error = hipHostMalloc(&m_cdf, size * sizeof(*m_cdf));
+            if(error != hipSuccess)
+            {
+                return ROCRAND_STATUS_ALLOCATION_FAILED;
+            }
+        }
+        const rocrand_status status = factory_t::allocate(size, offset, m_distribution);
+        if(status != ROCRAND_STATUS_SUCCESS)
+        {
+            return status;
+        }
+
+        m_initialized = true;
+        return ROCRAND_STATUS_SUCCESS;
+    }
+
+    rocrand_status set_stream(const hipStream_t stream)
+    {
+        const rocrand_status status
+            = System::is_host_func_blocking(stream, m_is_host_func_blocking);
+        if(status != ROCRAND_STATUS_SUCCESS)
+        {
+            return status;
+        }
+        m_stream = stream;
+        return ROCRAND_STATUS_SUCCESS;
+    }
+
+    std::variant<rocrand_status, distribution_t> get_distribution(const double lambda)
+    {
+        if(!m_initialized)
+        {
+            const rocrand_status status = init();
+            if(status != ROCRAND_STATUS_SUCCESS)
+            {
+                return status;
+            }
+        }
+
+        std::unique_lock lock(m_mutex, std::defer_lock_t{});
+        if(!m_is_host_func_blocking)
+        {
+            lock.lock();
+        }
+
+        const bool changed = lambda != m_lambda;
+        if(changed && lambda <= rocrand_device::detail::lambda_threshold_huge)
+        {
+            auto arg = std::make_unique<update_discrete_distribution_arg>(
+                update_discrete_distribution_arg{lambda, this});
+            const rocrand_status status
+                = System::launch_host_func(m_stream, update_discrete_distribution, arg.release());
+            if(status != ROCRAND_STATUS_SUCCESS)
+            {
+                return status;
+            }
+            if constexpr(System::is_device() && (Method & DISCRETE_METHOD_ALIAS))
+            {
+                hipError_t error
+                    = hipMemcpyAsync(m_distribution.probability,
+                                     m_probability,
+                                     m_distribution.size * sizeof(*m_distribution.probability),
+                                     hipMemcpyHostToDevice,
+                                     m_stream);
+                if(error != hipSuccess)
+                {
+                    return ROCRAND_STATUS_INTERNAL_ERROR;
+                }
+                error = hipMemcpyAsync(m_distribution.alias,
+                                       m_alias,
+                                       m_distribution.size * sizeof(*m_distribution.alias),
+                                       hipMemcpyHostToDevice,
+                                       m_stream);
+                if(error != hipSuccess)
+                {
+                    return ROCRAND_STATUS_INTERNAL_ERROR;
+                }
+            }
+            if constexpr(System::is_device() && (Method & DISCRETE_METHOD_CDF))
+            {
+                const hipError_t error
+                    = hipMemcpyAsync(m_distribution.cdf,
+                                     m_cdf,
+                                     m_distribution.size * sizeof(*m_distribution.cdf),
+                                     hipMemcpyHostToDevice,
+                                     m_stream);
+                if(error != hipSuccess)
+                {
+                    return ROCRAND_STATUS_INTERNAL_ERROR;
+                }
+            }
+        }
+
+        rocrand_discrete_distribution_st distribution_copy = m_distribution;
+        calculate_poisson_size(lambda, distribution_copy.size, distribution_copy.offset);
+        return distribution_t(distribution_copy, lambda);
+    }
+
 private:
-    double lambda = 0.0;
+    bool                             m_initialized           = false;
+    bool                             m_is_host_func_blocking = true;
+    hipStream_t                      m_stream                = 0;
+    std::mutex                       m_mutex;
+    double*                          m_probability  = nullptr;
+    unsigned int*                    m_alias        = nullptr;
+    double*                          m_cdf          = nullptr;
+    double                           m_lambda       = 0;
+    rocrand_discrete_distribution_st m_distribution = {};
+
+    struct update_discrete_distribution_arg
+    {
+        double                        lambda;
+        poisson_distribution_manager* manager;
+    };
+
+    static void update_discrete_distribution(void* user_data)
+    {
+        std::unique_ptr<update_discrete_distribution_arg> arg(
+            reinterpret_cast<update_discrete_distribution_arg*>(user_data));
+        std::unique_lock lock(arg->manager->m_mutex, std::defer_lock_t{});
+        if(!arg->manager->m_is_host_func_blocking)
+        {
+            lock.lock();
+        }
+        unsigned int        size;
+        unsigned int        offset;
+        std::vector<double> poisson_probabilities
+            = calculate_poisson_probabilities(arg->lambda, size, offset);
+        assert(size <= arg->manager->m_distribution.size);
+        factory_t::normalize(poisson_probabilities, size);
+        if constexpr((Method & DISCRETE_METHOD_ALIAS) != 0)
+        {
+            factory_t::create_alias_table(poisson_probabilities,
+                                          size,
+                                          arg->manager->m_probability,
+                                          arg->manager->m_alias);
+        }
+        if constexpr((Method & DISCRETE_METHOD_CDF) != 0)
+        {
+            factory_t::create_cdf(poisson_probabilities, size, arg->manager->m_cdf);
+        }
+        arg->manager->m_lambda = arg->lambda;
+        if constexpr(!System::is_device())
+        {
+            if constexpr((Method & DISCRETE_METHOD_ALIAS) != 0)
+            {
+                std::copy_n(arg->manager->m_probability,
+                            size,
+                            arg->manager->m_distribution.probability);
+                std::copy_n(arg->manager->m_alias, size, arg->manager->m_distribution.alias);
+            }
+            if constexpr((Method & DISCRETE_METHOD_CDF) != 0)
+            {
+                std::copy_n(arg->manager->m_cdf, size, arg->manager->m_distribution.cdf);
+            }
+        }
+    }
 };
 
 // Mrg32k3a and Mrg31k3p
@@ -166,13 +380,13 @@ private:
 template<typename state_type, bool IsHostSide = false>
 struct mrg_engine_poisson_distribution
 {
-    using distribution_type = poisson_distribution<DISCRETE_METHOD_ALIAS, IsHostSide>;
+    using distribution_type                    = poisson_distribution<DISCRETE_METHOD_ALIAS>;
     static constexpr unsigned int input_width = 1;
     static constexpr unsigned int output_width = 1;
 
     distribution_type dis;
 
-    mrg_engine_poisson_distribution(distribution_type dis) : dis(dis) {}
+    explicit mrg_engine_poisson_distribution(distribution_type dis) : dis(dis) {}
 
     __host__ __device__
     void operator()(const unsigned int (&input)[1], unsigned int (&output)[1]) const

--- a/library/src/rng/generator_type.hpp
+++ b/library/src/rng/generator_type.hpp
@@ -44,7 +44,7 @@ struct rocrand_generator_base_type
     virtual rocrand_status   set_order(rocrand_ordering order) = 0;
 
     virtual hipStream_t get_stream() const             = 0;
-    virtual void        set_stream(hipStream_t stream) = 0;
+    virtual rocrand_status set_stream(hipStream_t stream) = 0;
 
     virtual rocrand_status set_dimensions(unsigned int dimensions) = 0;
 
@@ -128,7 +128,7 @@ struct generator_type : rocrand_generator_base_type
         return m_generator.get_stream();
     }
 
-    void set_stream(hipStream_t stream) override final
+    rocrand_status set_stream(hipStream_t stream) override final
     {
         return m_generator.set_stream(stream);
     }

--- a/library/src/rng/mrg.hpp
+++ b/library/src/rng/mrg.hpp
@@ -163,6 +163,9 @@ public:
     using base_type   = generator_impl_base;
     using engine_type = Engine;
     using system_type = System;
+    using poisson_distribution_manager_t
+        = poisson_distribution_manager<DISCRETE_METHOD_ALIAS, system_type>;
+    using poisson_distribution_t = typename poisson_distribution_manager_t::distribution_t;
 
     mrg_generator_template(unsigned long long seed   = 0,
                            unsigned long long offset = 0,
@@ -265,6 +268,17 @@ public:
         return ROCRAND_STATUS_SUCCESS;
     }
 
+    rocrand_status set_stream(hipStream_t stream)
+    {
+        const rocrand_status status = m_poisson.set_stream(stream);
+        if(status != ROCRAND_STATUS_SUCCESS)
+        {
+            return status;
+        }
+        base_type::set_stream(stream);
+        return ROCRAND_STATUS_SUCCESS;
+    }
+
     rocrand_status init()
     {
         if(m_engines_initialized)
@@ -305,6 +319,12 @@ public:
             m_engines_size,
             m_seed,
             m_offset / m_engines_size);
+        if(status != ROCRAND_STATUS_SUCCESS)
+        {
+            return status;
+        }
+
+        status = m_poisson.init();
         if(status != ROCRAND_STATUS_SUCCESS)
         {
             return status;
@@ -405,17 +425,13 @@ public:
 
     rocrand_status generate_poisson(unsigned int* data, size_t data_size, double lambda)
     {
-        try
+        auto dis = m_poisson.get_distribution(lambda);
+        if(auto* error_status = std::get_if<rocrand_status>(&dis))
         {
-            m_poisson.set_lambda(lambda);
+            return *error_status;
         }
-        catch(rocrand_status status)
-        {
-            return status;
-        }
-        mrg_engine_poisson_distribution<engine_type, !system_type::is_device()> distribution(
-            m_poisson.dis);
-        return generate(data, data_size, distribution);
+        mrg_engine_poisson_distribution<engine_type> mrg_dis(std::get<poisson_distribution_t>(dis));
+        return generate(data, data_size, mrg_dis);
     }
 
 private:
@@ -439,7 +455,7 @@ private:
     unsigned long long m_seed;
 
     // For caching of Poisson for consecutive generations with the same lambda
-    poisson_distribution_manager<DISCRETE_METHOD_ALIAS, !system_type::is_device()> m_poisson;
+    poisson_distribution_manager_t m_poisson;
 
     // m_seed from base_type
     // m_offset from base_type

--- a/library/src/rng/xorwow.hpp
+++ b/library/src/rng/xorwow.hpp
@@ -170,6 +170,9 @@ public:
     using base_type   = generator_impl_base;
     using engine_type = xorwow_device_engine;
     using system_type = System;
+    using poisson_distribution_manager_t
+        = poisson_distribution_manager<DISCRETE_METHOD_ALIAS, system_type>;
+    using poisson_distribution_t = typename poisson_distribution_manager_t::distribution_t;
 
     xorwow_generator_template(unsigned long long seed   = 0,
                               unsigned long long offset = 0,
@@ -265,6 +268,17 @@ public:
         return ROCRAND_STATUS_SUCCESS;
     }
 
+    rocrand_status set_stream(hipStream_t stream)
+    {
+        const rocrand_status status = m_poisson.set_stream(stream);
+        if(status != ROCRAND_STATUS_SUCCESS)
+        {
+            return status;
+        }
+        base_type::set_stream(stream);
+        return ROCRAND_STATUS_SUCCESS;
+    }
+
     rocrand_status init()
     {
         if (m_engines_initialized)
@@ -305,6 +319,12 @@ public:
             m_engines_size,
             m_seed,
             m_offset / m_engines_size);
+        if(status != ROCRAND_STATUS_SUCCESS)
+        {
+            return status;
+        }
+
+        status = m_poisson.init();
         if(status != ROCRAND_STATUS_SUCCESS)
         {
             return status;
@@ -408,15 +428,12 @@ public:
 
     rocrand_status generate_poisson(unsigned int * data, size_t data_size, double lambda)
     {
-        try
+        auto dis = m_poisson.get_distribution(lambda);
+        if(auto* error_status = std::get_if<rocrand_status>(&dis))
         {
-            m_poisson.set_lambda(lambda);
+            return *error_status;
         }
-        catch(rocrand_status status)
-        {
-            return status;
-        }
-        return generate(data, data_size, m_poisson.dis);
+        return generate(data, data_size, std::get<poisson_distribution_t>(dis));
     }
 
 private:
@@ -428,7 +445,7 @@ private:
     unsigned long long m_seed;
 
     // For caching of Poisson for consecutive generations with the same lambda
-    poisson_distribution_manager<DISCRETE_METHOD_ALIAS, !system_type::is_device()> m_poisson;
+    poisson_distribution_manager_t m_poisson;
 
     // m_seed from base_type
     // m_offset from base_type

--- a/test/internal/test_poisson_distribution.cpp
+++ b/test/internal/test_poisson_distribution.cpp
@@ -18,6 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#include "test_common.hpp"
+#include "test_rocrand_common.hpp"
 #include <gtest/gtest.h>
 #include <stdio.h>
 
@@ -27,29 +29,6 @@
 #include <rng/distribution/poisson.hpp>
 
 using namespace rocrand_impl::host;
-
-template<typename T>
-double get_mean(std::vector<T> values)
-{
-    double mean = 0.0f;
-    for(auto v : values)
-    {
-        mean += static_cast<double>(v);
-    }
-    return mean / values.size();
-}
-
-template<typename T>
-double get_variance(std::vector<T> values, double mean)
-{
-    double variance = 0.0f;
-    for(auto v : values)
-    {
-        const double x = static_cast<double>(v) - mean;
-        variance += x * x;
-    }
-    return variance / values.size();
-}
 
 class poisson_distribution_tests : public ::testing::TestWithParam<double>
 {};
@@ -61,19 +40,28 @@ TEST_P(poisson_distribution_tests, mean_var)
     std::random_device rd;
     std::mt19937       gen(rd());
 
-    poisson_distribution<DISCRETE_METHOD_ALIAS, true> dis;
-    dis.set_lambda(lambda);
+    using distribution_factory_t = discrete_distribution_factory<DISCRETE_METHOD_ALIAS, true>;
+
+    unsigned int              size;
+    unsigned int              offset;
+    const std::vector<double> poisson_probabilities
+        = calculate_poisson_probabilities(lambda, size, offset);
+    rocrand_discrete_distribution_st discrete_dist;
+    ROCRAND_CHECK(
+        distribution_factory_t::create(poisson_probabilities, size, offset, discrete_dist));
+
+    poisson_distribution<DISCRETE_METHOD_ALIAS> dis(discrete_dist, lambda);
 
     const size_t samples_count = static_cast<size_t>(std::max(2.0, sqrt(lambda))) * 100000;
     std::vector<unsigned int> values(samples_count);
 
     for(size_t si = 0; si < samples_count; si++)
     {
-        const unsigned int v = dis(gen());
+        const unsigned int v = dis(static_cast<unsigned int>(gen()));
         values[si]           = v;
     }
 
-    dis.deallocate();
+    distribution_factory_t::deallocate(discrete_dist);
 
     const double mean     = get_mean(values);
     const double variance = get_variance(values, mean);
@@ -90,8 +78,16 @@ TEST_P(poisson_distribution_tests, histogram_compare)
     SCOPED_TRACE(testing::Message() << "with seed = " << seed);
     std::mt19937 gen(seed);
 
-    poisson_distribution<DISCRETE_METHOD_ALIAS, true> dis;
-    dis.set_lambda(lambda);
+    using distribution_factory_t = discrete_distribution_factory<DISCRETE_METHOD_ALIAS, true>;
+    unsigned int              size;
+    unsigned int              offset;
+    const std::vector<double> poisson_probabilities
+        = calculate_poisson_probabilities(lambda, size, offset);
+    rocrand_discrete_distribution_st discrete_dist;
+    ROCRAND_CHECK(
+        distribution_factory_t::create(poisson_probabilities, size, offset, discrete_dist));
+
+    poisson_distribution<DISCRETE_METHOD_ALIAS> dis(discrete_dist, lambda);
 
     const size_t samples_count = static_cast<size_t>(std::max(2.0, sqrt(lambda))) * 100000;
     const size_t bin_size      = static_cast<size_t>(std::max(2.0, sqrt(lambda)));
@@ -100,7 +96,7 @@ TEST_P(poisson_distribution_tests, histogram_compare)
 
     for(size_t si = 0; si < samples_count; si++)
     {
-        const unsigned int v   = dis(gen());
+        const unsigned int v   = dis(static_cast<unsigned int>(gen()));
         const size_t       bin = v / bin_size;
         if(bin < bins_count)
         {
@@ -108,7 +104,7 @@ TEST_P(poisson_distribution_tests, histogram_compare)
         }
     }
 
-    dis.deallocate();
+    distribution_factory_t::deallocate(discrete_dist);
 
     // for small lambda, histogram test is inaccurate due to relatively large bins
     // for large lambda, expected value calculation is inaccurate due to non-finite terms

--- a/test/internal/test_rocrand_generator_type.cpp
+++ b/test/internal/test_rocrand_generator_type.cpp
@@ -63,6 +63,12 @@ struct dummy_generator : generator_impl_base
         return ROCRAND_STATUS_SUCCESS;
     }
 
+    rocrand_status set_stream(hipStream_t stream)
+    {
+        generator_impl_base::set_stream(stream);
+        return ROCRAND_STATUS_SUCCESS;
+    }
+
     rocrand_status init()
     {
         return ROCRAND_STATUS_SUCCESS;

--- a/test/test_common.hpp
+++ b/test/test_common.hpp
@@ -137,4 +137,27 @@ void assert_near(const std::vector<T>& a, const std::vector<T>& b, double eps)
     }
 }
 
+template<typename T>
+double get_mean(const std::vector<T>& values)
+{
+    double mean = 0.0f;
+    for(auto v : values)
+    {
+        mean += static_cast<double>(v);
+    }
+    return mean / values.size();
+}
+
+template<typename T>
+double get_variance(const std::vector<T>& values, double mean)
+{
+    double variance = 0.0f;
+    for(auto v : values)
+    {
+        const double x = static_cast<double>(v) - mean;
+        variance += x * x;
+    }
+    return variance / values.size();
+}
+
 #endif // TEST_COMMON_HPP_

--- a/test/test_rocrand_generate_poisson.cpp
+++ b/test/test_rocrand_generate_poisson.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include <stdio.h>
 #include <gtest/gtest.h>
 
 #include <hip/hip_runtime.h>
@@ -26,6 +25,9 @@
 
 #include "test_common.hpp"
 #include "test_rocrand_common.hpp"
+
+#include <random>
+#include <vector>
 
 class rocrand_generate_poisson_tests : public ::testing::TestWithParam<rocrand_rng_type>
 {};
@@ -70,6 +72,69 @@ void test_out_of_range(GenerateFunc generate_func)
     ROCRAND_CHECK(rocrand_destroy_generator(generator));
 }
 
+void test_multiple_lambdas(const rocrand_rng_type rng_type, const hipStream_t stream)
+{
+    rocrand_generator generator;
+    ROCRAND_CHECK(rocrand_create_generator(&generator, rng_type));
+    ROCRAND_CHECK(rocrand_set_stream(generator, stream));
+
+    constexpr size_t       num_invocations = 20;
+    constexpr size_t       size            = 125638;
+    constexpr double       min_lambda      = 0.001;
+    constexpr double       max_lambda      = 5000;
+    constexpr unsigned int seed            = 654321;
+
+    std::uniform_real_distribution<double> lambda_distribution(min_lambda, max_lambda);
+    std::default_random_engine             rng(seed);
+    std::vector<double>                    lambdas(num_invocations);
+    for(auto& lambda : lambdas)
+    {
+        lambda = lambda_distribution(rng);
+    }
+
+    std::vector<unsigned int*> d_results(num_invocations);
+    for(auto& d_ptr : d_results)
+    {
+        HIP_CHECK(hipMallocHelper(&d_ptr, sizeof(*d_ptr) * size));
+    }
+
+    std::vector<std::vector<unsigned int>> h_results(num_invocations);
+    for(auto& h_vec : h_results)
+    {
+        h_vec.resize(size);
+    }
+
+    for(size_t i = 0; i < num_invocations; ++i)
+    {
+        ROCRAND_CHECK(rocrand_generate_poisson(generator, d_results[i], size, lambdas[i]));
+    }
+
+    HIP_CHECK(hipStreamSynchronize(stream));
+
+    for(size_t i = 0; i < num_invocations; ++i)
+    {
+        const auto lambda = lambdas[i];
+        auto&      values = h_results[i];
+        HIP_CHECK(hipMemcpy(values.data(),
+                            d_results[i],
+                            sizeof(*d_results[i]) * size,
+                            hipMemcpyDeviceToHost));
+
+        const double mean     = get_mean(values);
+        const double variance = get_variance(values, mean);
+
+        EXPECT_NEAR(mean, lambda, std::max(1.0, lambda * 3e-2));
+        EXPECT_NEAR(variance, lambda, std::max(1.0, lambda * 2e-2));
+    }
+
+    for(auto* d_ptr : d_results)
+    {
+        HIP_CHECK(hipFree(d_ptr));
+    }
+
+    ROCRAND_CHECK(rocrand_destroy_generator(generator));
+}
+
 TEST_P(rocrand_generate_poisson_tests, generate_test)
 {
     test_generate<unsigned int>(
@@ -95,6 +160,19 @@ TEST_P(rocrand_generate_poisson_tests, out_of_range_test)
     test_out_of_range<unsigned int>(
         [](rocrand_generator gen, unsigned int* data, size_t size, double lambda)
         { return rocrand_generate_poisson(gen, data, size, lambda); });
+}
+
+TEST_P(rocrand_generate_poisson_tests, multiple_lambdas_default_stream)
+{
+    test_multiple_lambdas(GetParam(), hipStreamDefault);
+}
+
+TEST_P(rocrand_generate_poisson_tests, multiple_lambdas_non_blocking_stream)
+{
+    hipStream_t stream;
+    HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
+    test_multiple_lambdas(GetParam(), stream);
+    HIP_CHECK(hipStreamDestroy(stream));
 }
 
 INSTANTIATE_TEST_SUITE_P(rocrand_generate_poisson_tests,

--- a/test/test_rocrand_hipgraphs.cpp
+++ b/test/test_rocrand_hipgraphs.cpp
@@ -140,6 +140,50 @@ TEST_P(rocrand_hipgraph_generate_tests, uniform_float_test)
     HIP_CHECK(hipStreamDestroy(stream));
 }
 
+TEST_P(rocrand_hipgraph_generate_tests, poisson_test)
+{
+    const rocrand_rng_type rng_type = GetParam();
+
+    rocrand_generator generator;
+    ROCRAND_CHECK(rocrand_create_generator(&generator, rng_type));
+
+    ROCRAND_CHECK(rocrand_initialize_generator(generator));
+
+    constexpr size_t size = 12563;
+    unsigned int*    data;
+    HIP_CHECK(hipMallocHelper(&data, size * sizeof(*data)));
+    HIP_CHECK(hipDeviceSynchronize());
+
+    // Default stream does not support hipGraph stream capture, so create a non-blocking one
+    hipStream_t stream = 0;
+    HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
+    rocrand_set_stream(generator, stream);
+
+    hipGraphExec_t graph_instance;
+    hipGraph_t     graph = test_utils::createGraphHelper(stream);
+
+    // Any sizes
+    ROCRAND_CHECK(rocrand_generate_poisson(generator, data, 1, 10.0));
+
+    graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+    test_utils::resetGraphHelper(graph, graph_instance, stream);
+
+    // Any alignment
+    ROCRAND_CHECK(rocrand_generate_poisson(generator, data + 1, 2, 500.0));
+
+    graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+    test_utils::resetGraphHelper(graph, graph_instance, stream);
+
+    ROCRAND_CHECK(rocrand_generate_poisson(generator, data, size, 5000.0));
+
+    graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+
+    HIP_CHECK(hipFree(data));
+    ROCRAND_CHECK(rocrand_destroy_generator(generator));
+    test_utils::cleanupGraphHelper(graph, graph_instance);
+    HIP_CHECK(hipStreamDestroy(stream));
+}
+
 INSTANTIATE_TEST_SUITE_P(rocrand_hipgraph_generate_tests,
                         rocrand_hipgraph_generate_tests,
                         ::testing::ValuesIn(rng_types));

--- a/test/test_rocrand_host.cpp
+++ b/test/test_rocrand_host.cpp
@@ -47,39 +47,99 @@ std::vector<unsigned long long> get_seeds()
     return ret;
 }
 
-constexpr rocrand_rng_type host_rng_types[] = {
-    ROCRAND_RNG_PSEUDO_PHILOX4_32_10,
-    ROCRAND_RNG_PSEUDO_LFSR113,
-    ROCRAND_RNG_PSEUDO_MRG31K3P,
-    ROCRAND_RNG_PSEUDO_MRG32K3A,
-    ROCRAND_RNG_PSEUDO_MT19937,
-    ROCRAND_RNG_PSEUDO_MTGP32,
-    ROCRAND_RNG_PSEUDO_THREEFRY2_32_20,
-    ROCRAND_RNG_PSEUDO_THREEFRY2_64_20,
-    ROCRAND_RNG_PSEUDO_THREEFRY4_32_20,
-    ROCRAND_RNG_PSEUDO_THREEFRY4_64_20,
-    ROCRAND_RNG_PSEUDO_XORWOW,
-    ROCRAND_RNG_QUASI_SCRAMBLED_SOBOL32,
-    ROCRAND_RNG_QUASI_SCRAMBLED_SOBOL64,
-    ROCRAND_RNG_QUASI_SOBOL32,
-    ROCRAND_RNG_QUASI_SOBOL64,
+struct host_test_params
+{
+    rocrand_rng_type rng_type;
+    bool             blocking_host_generator;
+    bool             use_default_stream;
+
+    friend std::ostream& operator<<(std::ostream& os, const host_test_params& params)
+    {
+        os << "{ "
+           << "rng_type: " << params.rng_type << ", blocking: " << params.blocking_host_generator
+           << ", default_stream: " << params.use_default_stream << " }";
+        return os;
+    }
+};
+
+constexpr host_test_params host_test_params_array[] = {
+    {   ROCRAND_RNG_PSEUDO_PHILOX4_32_10, false,  true},
+    {         ROCRAND_RNG_PSEUDO_LFSR113, false,  true},
+    {        ROCRAND_RNG_PSEUDO_MRG31K3P, false,  true},
+    {        ROCRAND_RNG_PSEUDO_MRG32K3A, false,  true},
+    {         ROCRAND_RNG_PSEUDO_MT19937, false,  true},
+    {          ROCRAND_RNG_PSEUDO_MTGP32, false,  true},
+    { ROCRAND_RNG_PSEUDO_THREEFRY2_32_20, false,  true},
+    { ROCRAND_RNG_PSEUDO_THREEFRY2_64_20, false,  true},
+    { ROCRAND_RNG_PSEUDO_THREEFRY4_32_20, false,  true},
+    { ROCRAND_RNG_PSEUDO_THREEFRY4_64_20, false,  true},
+    {          ROCRAND_RNG_PSEUDO_XORWOW, false,  true},
+    {ROCRAND_RNG_QUASI_SCRAMBLED_SOBOL32, false,  true},
+    {ROCRAND_RNG_QUASI_SCRAMBLED_SOBOL64, false,  true},
+    {          ROCRAND_RNG_QUASI_SOBOL32, false,  true},
+    {          ROCRAND_RNG_QUASI_SOBOL64, false,  true},
+
+    {          ROCRAND_RNG_PSEUDO_XORWOW, false, false},
+    {          ROCRAND_RNG_PSEUDO_XORWOW,  true, false},
+    {          ROCRAND_RNG_PSEUDO_XORWOW,  true,  true},
+
+    {          ROCRAND_RNG_QUASI_SOBOL32, false, false},
+    {          ROCRAND_RNG_QUASI_SOBOL32,  true, false},
+    {          ROCRAND_RNG_QUASI_SOBOL32,  true,  true},
 };
 
 } // namespace
 
-class rocrand_generate_host_test : public ::testing::TestWithParam<rocrand_rng_type>
-{};
-
-void test_int(const rocrand_rng_type rng_type, const size_t test_size)
+class rocrand_generate_host_test : public ::testing::TestWithParam<host_test_params>
 {
-    if(rng_type == ROCRAND_RNG_PSEUDO_MT19937)
+protected:
+    void SetUp() override
     {
-        ROCRAND_SKIP_SLOW_TEST_IF_NOT_ENABLED();
+        if(GetParam().rng_type == ROCRAND_RNG_PSEUDO_MT19937)
+        {
+            ROCRAND_SKIP_SLOW_TEST_IF_NOT_ENABLED();
+        }
+        if(!GetParam().use_default_stream)
+        {
+            HIP_CHECK(hipStreamCreateWithFlags(&m_custom_stream, hipStreamNonBlocking));
+        }
     }
 
-    rocrand_generator generator;
-    ROCRAND_CHECK(rocrand_create_generator_host(&generator, rng_type));
+    void TearDown() override
+    {
+        if(!GetParam().use_default_stream)
+        {
+            HIP_CHECK(hipStreamDestroy(m_custom_stream));
+        }
+    }
 
+    rocrand_generator get_generator()
+    {
+        const auto        params = GetParam();
+        rocrand_generator generator;
+        if(params.blocking_host_generator)
+        {
+            EXPECT_EQ(ROCRAND_STATUS_SUCCESS,
+                      rocrand_create_generator_host_blocking(&generator, params.rng_type));
+        }
+        else
+        {
+            EXPECT_EQ(ROCRAND_STATUS_SUCCESS,
+                      rocrand_create_generator_host(&generator, params.rng_type));
+        }
+        if(!params.use_default_stream)
+        {
+            EXPECT_EQ(ROCRAND_STATUS_SUCCESS, rocrand_set_stream(generator, m_custom_stream));
+        }
+        return generator;
+    }
+
+private:
+    hipStream_t m_custom_stream;
+};
+
+void test_int(rocrand_generator generator, const size_t test_size)
+{
     std::vector<unsigned int> results(test_size);
     for(size_t i = 0; i < seeds_count + random_seeds_count; ++i)
     {
@@ -109,29 +169,24 @@ void test_int(const rocrand_rng_type rng_type, const size_t test_size)
 
 TEST_P(rocrand_generate_host_test, int_test)
 {
-    test_int(GetParam(), 11111);
+    test_int(get_generator(), 11111);
 }
 
 TEST_P(rocrand_generate_host_test, int_test_large)
 {
     ROCRAND_SKIP_SLOW_TEST_IF_NOT_ENABLED();
     constexpr size_t large_test_size = size_t(INT_MAX) + 1;
-    test_int(GetParam(), large_test_size);
+    test_int(get_generator(), large_test_size);
 }
 
 template<typename Type, typename F>
-void test_int_parity(rocrand_rng_type                       rng_type,
+void test_int_parity(rocrand_generator                      host_generator,
+                     rocrand_rng_type                       rng_type,
                      F                                      generate,
                      const std::vector<unsigned long long>& seeds = get_seeds())
 {
-    if(rng_type == ROCRAND_RNG_PSEUDO_MT19937)
-    {
-        ROCRAND_SKIP_SLOW_TEST_IF_NOT_ENABLED();
-    }
-
-    rocrand_generator device_generator, host_generator;
+    rocrand_generator device_generator;
     ROCRAND_CHECK(rocrand_create_generator(&device_generator, rng_type));
-    ROCRAND_CHECK(rocrand_create_generator_host(&host_generator, rng_type));
 
     std::vector<Type> host_results(218192);
     std::vector<Type> device_results(host_results.size());
@@ -152,6 +207,7 @@ void test_int_parity(rocrand_rng_type                       rng_type,
                             output,
                             host_results.size() * sizeof(Type),
                             hipMemcpyDeviceToHost));
+        HIP_CHECK(hipDeviceSynchronize());
 
         assert_eq(host_results, device_results);
     }
@@ -163,32 +219,27 @@ void test_int_parity(rocrand_rng_type                       rng_type,
 
 TEST_P(rocrand_generate_host_test, char_parity_test)
 {
-    test_int_parity<unsigned char>(GetParam(), rocrand_generate_char);
+    test_int_parity<unsigned char>(get_generator(), GetParam().rng_type, rocrand_generate_char);
 }
 
 TEST_P(rocrand_generate_host_test, short_parity_test)
 {
-    test_int_parity<unsigned short>(GetParam(), rocrand_generate_short);
+    test_int_parity<unsigned short>(get_generator(), GetParam().rng_type, rocrand_generate_short);
 }
 
 TEST_P(rocrand_generate_host_test, int_parity_test)
 {
-    test_int_parity<unsigned int>(GetParam(), rocrand_generate);
+    test_int_parity<unsigned int>(get_generator(), GetParam().rng_type, rocrand_generate);
 }
 
 template<typename Type, typename F>
-void test_uniform_parity(rocrand_rng_type                       rng_type,
+void test_uniform_parity(rocrand_generator                      host_generator,
+                         rocrand_rng_type                       rng_type,
                          F                                      generate,
                          const std::vector<unsigned long long>& seeds = get_seeds())
 {
-    if(rng_type == ROCRAND_RNG_PSEUDO_MT19937)
-    {
-        ROCRAND_SKIP_SLOW_TEST_IF_NOT_ENABLED();
-    }
-
-    rocrand_generator device_generator, host_generator;
+    rocrand_generator device_generator;
     ROCRAND_CHECK(rocrand_create_generator(&device_generator, rng_type));
-    ROCRAND_CHECK(rocrand_create_generator_host(&host_generator, rng_type));
 
     std::vector<Type> host_results(218192);
     std::vector<Type> device_results(host_results.size());
@@ -209,6 +260,7 @@ void test_uniform_parity(rocrand_rng_type                       rng_type,
                             output,
                             host_results.size() * sizeof(Type),
                             hipMemcpyDeviceToHost));
+        HIP_CHECK(hipDeviceSynchronize());
 
         assert_eq(host_results, device_results);
     }
@@ -220,21 +272,24 @@ void test_uniform_parity(rocrand_rng_type                       rng_type,
 
 TEST_P(rocrand_generate_host_test, uniform_half_parity_test)
 {
-    test_uniform_parity<half>(GetParam(), rocrand_generate_uniform_half);
+    test_uniform_parity<half>(get_generator(), GetParam().rng_type, rocrand_generate_uniform_half);
 }
 
 TEST_P(rocrand_generate_host_test, uniform_float_parity_test)
 {
-    test_uniform_parity<float>(GetParam(), rocrand_generate_uniform);
+    test_uniform_parity<float>(get_generator(), GetParam().rng_type, rocrand_generate_uniform);
 }
 
 TEST_P(rocrand_generate_host_test, uniform_double_parity_test)
 {
-    test_uniform_parity<double>(GetParam(), rocrand_generate_uniform_double);
+    test_uniform_parity<double>(get_generator(),
+                                GetParam().rng_type,
+                                rocrand_generate_uniform_double);
 }
 
 template<typename Type, typename F>
-void test_normal_parity(rocrand_rng_type                       rng_type,
+void test_normal_parity(rocrand_generator                      host_generator,
+                        rocrand_rng_type                       rng_type,
                         F                                      generate,
                         double                                 eps,
                         const std::vector<unsigned long long>& seeds = get_seeds())
@@ -247,9 +302,8 @@ void test_normal_parity(rocrand_rng_type                       rng_type,
     Type mean   = static_cast<Type>(-12.0);
     Type stddev = static_cast<Type>(2.4);
 
-    rocrand_generator device_generator, host_generator;
+    rocrand_generator device_generator;
     ROCRAND_CHECK(rocrand_create_generator(&device_generator, rng_type));
-    ROCRAND_CHECK(rocrand_create_generator_host(&host_generator, rng_type));
 
     std::vector<Type> host_results(218192);
     std::vector<Type> device_results(host_results.size());
@@ -271,6 +325,7 @@ void test_normal_parity(rocrand_rng_type                       rng_type,
                             output,
                             host_results.size() * sizeof(Type),
                             hipMemcpyDeviceToHost));
+        HIP_CHECK(hipDeviceSynchronize());
 
         // This rounding is required because the sine and cosine used in box-muller used in the normal
         // distribution is slightly different from the one used on the host.
@@ -284,43 +339,58 @@ void test_normal_parity(rocrand_rng_type                       rng_type,
 
 TEST_P(rocrand_generate_host_test, normal_half_parity_test)
 {
-    test_normal_parity<half>(GetParam(), rocrand_generate_normal_half, 0.1);
+    test_normal_parity<half>(get_generator(),
+                             GetParam().rng_type,
+                             rocrand_generate_normal_half,
+                             0.1);
 }
 
 TEST_P(rocrand_generate_host_test, normal_float_parity_test)
 {
-    test_normal_parity<float>(GetParam(), rocrand_generate_normal, 0.005);
+    test_normal_parity<float>(get_generator(), GetParam().rng_type, rocrand_generate_normal, 0.005);
 }
 
 TEST_P(rocrand_generate_host_test, normal_double_parity_test)
 {
-    test_normal_parity<double>(GetParam(), rocrand_generate_normal_double, 0.000001);
+    test_normal_parity<double>(get_generator(),
+                               GetParam().rng_type,
+                               rocrand_generate_normal_double,
+                               0.000001);
 }
 
 TEST_P(rocrand_generate_host_test, log_normal_half_parity_test)
 {
-    test_normal_parity<half>(GetParam(), rocrand_generate_log_normal_half, 0.05);
+    test_normal_parity<half>(get_generator(),
+                             GetParam().rng_type,
+                             rocrand_generate_log_normal_half,
+                             0.05);
 }
 
 TEST_P(rocrand_generate_host_test, log_normal_float_parity_test)
 {
-    test_normal_parity<float>(GetParam(), rocrand_generate_log_normal, 0.0001);
+    test_normal_parity<float>(get_generator(),
+                              GetParam().rng_type,
+                              rocrand_generate_log_normal,
+                              0.0001);
 }
 
 TEST_P(rocrand_generate_host_test, log_normal_double_parity_test)
 {
-    test_normal_parity<double>(GetParam(), rocrand_generate_log_normal_double, 0.0000001);
+    test_normal_parity<double>(get_generator(),
+                               GetParam().rng_type,
+                               rocrand_generate_log_normal_double,
+                               0.0000001);
 }
 
 TEST_P(rocrand_generate_host_test, poisson_parity_test)
 {
-    const rocrand_rng_type rng_type = GetParam();
+    const rocrand_rng_type rng_type = GetParam().rng_type;
     using Type                      = unsigned int;
     double lambda                   = 1.1;
 
-    rocrand_generator device_generator, host_generator;
+    rocrand_generator host_generator = get_generator();
+    rocrand_generator device_generator;
     ROCRAND_CHECK(rocrand_create_generator(&device_generator, rng_type));
-    ROCRAND_CHECK(rocrand_create_generator_host(&host_generator, rng_type));
 
     std::vector<Type> host_results(218192);
     std::vector<Type> device_results(host_results.size());
@@ -345,9 +415,10 @@ TEST_P(rocrand_generate_host_test, poisson_parity_test)
                             output,
                             host_results.size() * sizeof(Type),
                             hipMemcpyDeviceToHost));
-    }
+        HIP_CHECK(hipDeviceSynchronize());
 
-    assert_eq(host_results, device_results);
+        assert_eq(host_results, device_results);
+    }
 
     ROCRAND_CHECK(rocrand_destroy_generator(host_generator));
     ROCRAND_CHECK(rocrand_destroy_generator(device_generator));
@@ -356,4 +427,4 @@ TEST_P(rocrand_generate_host_test, poisson_parity_test)
 
 INSTANTIATE_TEST_SUITE_P(rocrand_generate_host_test,
                          rocrand_generate_host_test,
-                         ::testing::ValuesIn(host_rng_types));
+                         ::testing::ValuesIn(host_test_params_array));


### PR DESCRIPTION
## Notes for the reviewer

- The idea is the following: the size of the allocated discrete distribution increases monotonically with lambda. Above a certain threshold, the Poisson distribution can be approximated by a normal distribution (see `rocrand_poisson.hpp`). Therefore the discrete distribution vector can be pre-allocated to the size up to this threshold, and the calculation and host->device copy of the distribution's contents can be scheduled with stream semantics (therefore capture by hipGraphs becomes available).
- The implementation needed a complete refactoring of the contents of internal headers `discrete.hpp` and `poisson.hpp`. I suggest to review these two by reading the new versions of these headers from top to bottom (versus looking at the differences).
  - The storage, execution and lifetime management of the discrete distributions has been untangled into separate classes to allow for a more versatile use required by the new functionality.
  - `rocrand_discrete_distribution_st` is still the public-facing C-type data container.
  - A new `discrete_distribution_factory` collects static methods to manage the creation and destruction of `rocrand_discrete_distribution_st`.
  - `discrete_distribution_base` no longer inherits from `rocrand_discrete_distribution_st` and no longer manages its lifetime. Instead, its sole purpose is to generate values from the discrete distribution in the host generators, similarly to the other Distribution classes.
  - The same applies to `poisson_distribution`. It implements the dispatch between using the discrete distribution or approximating by a normal distribution, based on the lambda.
  - The RAII-style lifetime management and asynchronous update (based on lambda) to the poisson distribution has been added to `poisson_distribution_manager`.
  - The exception-based error handling has been replaced by returning error codes, to be consistent with the rest of the codebase.
- The returned `rocrand_status` from `rocrand_set_stream` has been wired to the internal API.
- The test coverage was extended by the following items:
  - `test_rocrand_generate_poisson` got a pair of new test cases, which generate a vector of poisson numbers with a large number of different random lambdas, without synchronization. One test executes on the default stream, while the other on a non-blocking stream.
  - A new case testing `rocrand_generate_poisson` is added to `test_rocrand_hipgraphs`.
  - `test_rocrand_host` is extended to cover generators created by `rocrand_create_generator_host_blocking`, as well as using host generators with non-blocking streams. Some combinations were added, but not all.